### PR TITLE
fix: panic if plugin_fn applied to main fn

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,6 +30,12 @@ pub fn plugin_fn(
         panic!("extism_pdk::plugin_fn expects a function with one argument, `()` may be used if no input is needed");
     }
 
+    if name == "main" {
+        panic!(
+            "extism_pdk::plugin_fn must not be applied to a `main` function. To fix, rename this to something other than `main`."
+        )
+    }
+
     match output {
         syn::ReturnType::Default => panic!(
             "extism_pdk::plugin_fn expects a return value, `()` may be used if no output is needed"


### PR DESCRIPTION
Addresses extism/extism#166

Results in: 
![image](https://user-images.githubusercontent.com/7517515/207709010-d4b42ff2-a44d-4bf2-85c7-4d8d5014e36c.png)

or on build:

```
   Compiling extism-pdk v0.1.0 (/home/nilslice/Projects/extism/rust-pdk)
error: custom attribute panicked
  --> examples/sum.rs:16:1
   |
16 | #[plugin_fn]
   | ^^^^^^^^^^^^
   |
   = help: message: extism_pdk::plugin_fn must not be applied to a `main` function. To fix, rename this to something other than `main`.

error: could not compile `extism-pdk` due to previous error

```