### PR TITLE
fix: carry over const/unsafe to inner function impl

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -56,7 +56,7 @@ pub fn plugin_fn(
     quote! {
         #[no_mangle]
         pub #constness #unsafety extern "C" fn #name() -> i32 {
-            fn inner #generics(#inputs) #output {
+            #constness #unsafety fn inner #generics(#inputs) #output {
                 #block
             }
 


### PR DESCRIPTION
Currently an `unsafe` function marked with `#[plugin_fn]` gets converted to a regular function because the inner function defined by the macro isn't marked as unsafe.