### PR TITLE
docs: Create a README and getting started guide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 extism-pdk-derive = {path = "./derive", version = "0.3.1"}
 extism-manifest = {version = "0.5.0", optional = true}
-extism-convert = {git = "https://github.com/extism/extism", version = "0.1"} # TODO: change this after extism-convert has been released
+extism-convert = { version = "0.2"}
 base64 = "0.21.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Since we don't need any system access for this, we can compile this to the light
 cargo build --target wasm32-unknown-unknown
 ```
 
-> *Note*: You can also put a default target in `.cargo/config.yml`:
-> ```yaml
+> *Note*: You can also put a default target in `.cargo/config.toml`:
+> ```toml
 > [build]
 >   target = "wasm32-unknown-unknown"
 > ```

--- a/README.md
+++ b/README.md
@@ -124,28 +124,15 @@ pub fn add(Json(add): Json<Add>) -> FnResult<Json<Sum>> {
 
 [plugin_fn](https://docs.rs/extism-pdk/latest/extism_pdk/attr.plugin_fn.html) is a nice macro abstraction but there may be times where you want more control. You can code directly to the raw ABI interface of export functions.
 
-> TODO: how do i use unwrap! here?
 
 ```rust
 #[no_mangle]
 pub unsafe extern "C" fn greet() -> i32 {
-    let name = input::<String>();
-
-    match name {
-        Err(e) => {
-            let err = format!("{:?}", e);
-            let mem = Memory::from_bytes(&err).unwrap();
-            extism_error_set(mem.offset());
-            1i32
-        }
-        Ok(n) => {
-            let result = format!("Hello, {}!", n);
-            output(result).unwrap();
-            0i32
-        }
-    }
+    let name = unwrap!(input::<String>());
+    let result = format!("Hello, {}!", name);
+    unwrap!(output(result));
+    0i32
 }
-```
 
 ## Configs
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,312 @@
 # Extism Rust PDK
 
-For more information about the Rust PDK, please [visit the docs](https://extism.org/docs/write-a-plugin/rust-pdk).
+This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
 
-Join the [Discord](https://discord.gg/cx3usBCWnc) and chat with us!
+## Install
+
+Make sure you generate a `lib` project:
+
+```bash
+cargo new --lib my-plugin
+```
+
+Add the library from [crates.io](https://crates.io/crates/extism-pdk).
+
+```bash
+cargo add extism-pdk
+```
+
+Change your `Cargo.toml` to set the crate-type to `cdylib`:
+
+```toml
+[lib]
+crate_type = ["cdylib"]
+```
+
+## Getting Started
+
+The goal of writing an [Extism plug-in](https://extism.org/docs/concepts/plug-in) is to compile the your rust code to a Wasm module with some special export functions that the host application can invoke. The first thing you should understand is creating an export. Let's write a simple program that exports a `greet` function which will take a name as a string and return a greeting string:
+
+
+```rust
+use extism_pdk::*;
+
+#[plugin_fn]
+pub fn greet(name: String) -> FnResult<String> {
+    Ok(format!("Hello, {}!", name))
+}
+```
+
+You since we don't need any system access for this, we can compile this to the
+bare wasm32-unknown-uknown target instead of using the wasi target:
+
+```bash
+cargo build --target wasm32-unknown-uknown
+```
+
+This will put your compiled wasm in `target/wasm32-unknown-uknown/debug`.
+We can now test it using the [Extism CLI](https://github.com/extism/cli)'s `run`
+command:
+
+```bash
+extism call target/wasm32-unknown-unknown/debug/my_plugin.wasm greet --input "Benjamin"
+# => Hello, Benjamin!
+```
+
+### More About Exports
+
+Adding the `plugin_fn` macro to your function does a couple things. It exposes your function as an export and it handles some of the lower level ABI details that allow you to express the high level types of your params and returns. Here are a few examples of exports you can define.
+
+### Primitive Types
+
+A common thing you may want to do is pass some primitive rust data back and forth.
+The `plugin_fn` macro can map these types for you:
+
+> TODO maybe link to docs.rs for convert here?
+
+> **Note**: The `plugin_fn` macro uses the [convert crate](https://github.com/extism/extism/tree/main/convert) to automatically convert and pass types across the guest / host boundary.
+
+```rust
+// f32 and f64
+#[plugin_fn]
+pub fn add_pi(input: f32) -> FnResult<f64> {
+    Ok(input as f64 + 3.14f64)
+}
+
+// i32 and i64
+#[plugin_fn]
+pub fn sum_42(input: i32) -> FnResult<i64> {
+    Ok(input as i64 + 42i64)
+}
+
+// u8 vec
+#[plugin_fn]
+pub fn process_bytes(input: Vec<u8>) -> FnResult<Vec<u8>> {
+    // process bytes here
+    Ok(input)
+}
+
+// empty unit
+// be aware that plugin_fn expects params, so for a void func
+// us this empty unit
+#[plugin_fn]
+pub fn hello(_: ()) -> FnResult<String> {
+    Ok("Hello, World!".into())
+}
+```
+
+### Json
+
+We provide a Json type that allows you to pass structs
+that implement serde::Deserialize as paramters and serde::Serialize
+as returns:
+
+```rust
+#[derive(serde::Deserialize)]
+struct Add {
+    a: u32,
+    b: u32,
+}
+#[derive(serde::Serialize)]
+struct Sum {
+    sum: u32,
+}
+
+#[plugin_fn]
+pub fn add(Json(add): Json<Add>) -> FnResult<Json<Sum>> {
+    let sum = Sum { sum: add.a + add.b };
+    Ok(Json(sum))
+}
+```
+
+### Raw Export Interface
+
+`plugin_fn` is a nice macro abstraction but there may be times where you want more control. You can code directly to the raw interface of exports.
+
+> TODO i've actually forgotten what this looks like, expand it and write out a useful example
+```rust
+pub const unsafe extern "C" fn greet() -> i32 {
+}
+```
+
+## Configs
+
+Configs are key-value pairs that can be passed in by the host when creating a
+plug-in. These can be useful to statically configure the plug-in with some config that exists across every function call. Here is a trivial example:
+
+```rust
+#[plugin_fn]
+pub fn greet(_: ()) -> FnResult<String> {
+    let user = config::get("user").expect("'user' key set in config");
+    Ok(format!("Hello, {}!", user))
+}
+```
+
+To test it, the [Extism CLI](https://github.com/extism/cli) has a `--config` option that lets you pass in `key=value` pairs:
+
+```bash
+extism call my_plugin.wasm greet --config user=Benjamin
+# => Hello, Benjamin!
+```
+
+## Variables
+
+Variables are another key-value mechanism but it's a mutable data store that
+will persist across function calls. These variables will persist as long as the
+host has loaded and not freed the plug-in:
+
+> TODO make this work:
+
+```rust
+#[plugin_fn]
+pub fn count(_: ()) -> FnResult<i64> {
+    let mut c = match var::get("count")? {
+        Some(c) => c,
+        None => 0,
+    };
+    c = c + 1;
+    set_var!("count", c);
+    Ok(c)
+}
+```
+
+## Logging
+
+Because Wasm modules by default do not have access to the system, printing to stdout won't work (unless you use WASI). Extism provides some simple logging macros that allow you to use the host application to log without having to give the plug-in permission to make syscalls.
+
+```rust
+#[plugin_fn]
+pub fn log_stuff(_: ()) -> FnResult<()> {
+    log!(LogLevel::Info, "Some info!");
+    log!(LogLevel::Warn, "A warning!");
+    log!(LogLevel::Error, "An error!");
+    Ok(())
+}
+```
+
+> TODO: why doesn't this log out info?
+
+From [Extism CLI](https://github.com/extism/cli):
+
+```bash
+extism call my_plugin.wasm log_stuff
+2023/09/30 11:52:17 Some info!
+2023/09/30 11:52:17 A warning!
+2023/09/30 11:52:17 An error!
+```
+
+> TODO: is there some place we can link to here?
+From the host, you need to make sure that you set a log file to stdout or some file location.
+
+## HTTP
+
+Sometimes it is useful to let a plug-in make HTTP calls.
+
+> **Note**: See [HttpRequest](https://docs.rs/extism-pdk/latest/extism_pdk/struct.HttpRequest.html) docs for more info on the request and response types:
+
+> TODO: let's show a meatier example here:
+
+```rust
+#[plugin_fn]
+pub fn http_get(Json(req): Json<HttpRequest>) -> FnResult<HttpResponse> {
+    info!("Request to: {}", req.url);
+    let res = http::request::<()>(&req, None)?;
+    Ok(res)
+}
+```
+
+## Imports (Host Functions)
+
+Like any other code module, Wasm not only let's you export functions to the outside world, you can
+import them too. Host Functions allow a plug-in to import functions defined in the host. For example,
+if you host application is written in python, it can pass a python function down to your rust plug-in
+where you can invoke it.
+
+This topic can get fairly complicated and we have not yet fully abstracted the Wasm knowledge you need
+to do this correctly. So we recommend reading out [concept doc on Host Functions](https://extism.org/docs/concepts/host-functions) before you get started.
+
+### A Simple Example
+
+Host functions have a similar interface as exports. You just need to declare them as `extern` on the top of your `lib.rs`. You only declare the interface as it is the host's responsibility to provide the implementation:
+
+> TODO maybe link again to docs.rs for convert here to remind people what types work?
+
+```rust
+#[host_fn]
+extern "ExtismHost" {
+    fn a_python_func(input: String) -> String; 
+}
+```
+
+To call this function, we must use the `unsafe` keyword. Also note that it automatically wraps the
+function return with a Result in case the call fails.
+
+
+```rust
+#[plugin_fn]
+pub fn hello_from_python(_: ()) -> FnResult<String> {
+    let output = unsafe { a_python_func("An argument to send to Python".into())? };
+    Ok(output)
+}
+```
+
+### Testing it out
+
+We can't really test this from the Extism CLI as something must provide the implementation. So let's
+write out the python side here. You should check the docs for the language you're using on the host side
+for how to implement host functions.
+
+> TODO: update this after we publish and hone new python-sdk
+
+```python
+from extism import host_fn, Function, ValType
+
+@host_fn
+def a_python_func(plugin, input_, output, _user_data):
+    # The plug-in is passing us a string
+    input_str = plugin.input_string(input_[0])
+
+    # just printing this out to prove we're in python land
+    print("Hello from python!")
+
+    # let's just add "!" to the input string
+    # but you could imagine here we could add some
+    # applicaiton code like query or manipulate the database
+    # or our application APIs
+    input_str += "!"
+
+    # set the new string as the return value to the plug-in
+    plugin.return_string(output[0], input_str)
+```
+
+Now when we load the plug-in we pass the host function:
+
+> TODO: we should have an explanation in the host function concept doc that we can link to here
+> that tells people how to determine their host function signature
+
+> TODO: test this code or come up with a simpler runnable example. Maybe there could be something in extism CLI baked in you can use to test host functions or some python script you can use.
+ 
+```python
+functions = [
+    Function(
+        "a_python_func",
+        [ValType.I64],
+        [ValType.I64],
+        a_python_func,
+    )
+]
+
+plugin = Plugin(manifest, functions=functions)
+result = plugin.call('hello_from_python')
+print(result)
+```
+
+```bash
+python3 app.py
+# => Hello from Python!
+# => An argument to send to Python!
+```
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -129,20 +129,18 @@ pub fn add(Json(add): Json<Add>) -> FnResult<Json<Sum>> {
 ```rust
 #[no_mangle]
 pub unsafe extern "C" fn greet() -> i32 {
-    let name_bytes = extism_load_input();
-    let name = from_utf8(&name_bytes);
+    let name = input::<String>();
 
     match name {
         Err(e) => {
             let err = format!("{:?}", e);
-            let mem = Memory::from_bytes(&err);
-            extism_error_set(mem.offset);
+            let mem = Memory::from_bytes(&err).unwrap();
+            extism_error_set(mem.offset());
             1i32
         }
         Ok(n) => {
             let result = format!("Hello, {}!", n);
-            let mem = Memory::from_bytes(result);
-            mem.set_output();
+            output(result).unwrap();
             0i32
         }
     }

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ cargo build --target wasm32-unknown-unknown
 ```
 
 > *Note*: You can also put a default target in `.cargo/config.toml`:
-> ```toml
-> [build]
-> target = "wasm32-unknown-unknown"
-> ```
+```toml
+[build]
+target = "wasm32-unknown-unknown"
+```
 
 This will put your compiled wasm in `target/wasm32-unknown-unknown/debug`.
 We can now test it using the [Extism CLI](https://github.com/extism/cli)'s `run`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Since we don't need any system access for this, we can compile this to the light
 cargo build --target wasm32-unknown-unknown
 ```
 
-> *Note*: You can also put a default target in `.cargo/config.toml`:
+> **Note**: You can also put a default target in `.cargo/config.toml`:
 ```toml
 [build]
 target = "wasm32-unknown-unknown"
@@ -206,12 +206,9 @@ Sometimes it is useful to let a plug-in make HTTP calls.
 
 > **Note**: See [HttpRequest](https://docs.rs/extism-pdk/latest/extism_pdk/struct.HttpRequest.html) docs for more info on the request and response types:
 
-> TODO: let's show a meatier example here:
-
 ```rust
 #[plugin_fn]
 pub fn http_get(Json(req): Json<HttpRequest>) -> FnResult<HttpResponse> {
-    info!("Request to: {}", req.url);
     let res = http::request::<()>(&req, None)?;
     Ok(res)
 }
@@ -246,7 +243,7 @@ function return with a Result in case the call fails.
 
 ```rust
 #[plugin_fn]
-pub fn hello_from_python(_: ()) -> FnResult<String> {
+pub fn hello_from_python() -> FnResult<String> {
     let output = unsafe { a_python_func("An argument to send to Python".into())? };
     Ok(output)
 }
@@ -257,8 +254,6 @@ pub fn hello_from_python(_: ()) -> FnResult<String> {
 We can't really test this from the Extism CLI as something must provide the implementation. So let's
 write out the python side here. You should check the docs for the language you're using on the host side
 for how to implement host functions.
-
-> TODO: update this after we publish and hone new python-sdk
 
 ```python
 from extism import host_fn, Function, ValType
@@ -282,11 +277,6 @@ def a_python_func(plugin, input_, output, _user_data):
 ```
 
 Now when we load the plug-in we pass the host function:
-
-> TODO: we should have an explanation in the host function concept doc that we can link to here
-> that tells people how to determine their host function signature
-
-> TODO: test this code or come up with a simpler runnable example. Maybe there could be something in extism CLI baked in you can use to test host functions or some python script you can use.
  
 ```python
 functions = [

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ extism call target/wasm32-unknown-unknown/debug/my_plugin.wasm greet --input "Be
 # => Hello, Benjamin!
 ```
 
+> **Note**: We also have a web-based, plug-in tester called the [Extism Playground](https://playground.extism.org/)
+
 ### More About Exports
 
 Adding the `plugin_fn` macro to your function does a couple things. It exposes your function as an export and it handles some of the lower level ABI details that allow you to declare your Wasm function as if it were a normal rust function. Here are a few examples of exports you can define.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Extism Rust PDK
-![crates.io](https://img.shields.io/crates/v/extism_pdk.svg)
+[![crates.io](https://img.shields.io/crates/v/extism_pdk.svg)](https://crates.io/crates/extism-pdk)
 
 This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pub fn greet(name: String) -> FnResult<String> {
 }
 ```
 
-Since we don't need any system access for this, we can compile this to the lightweight `wasm32-unknown-uknown` target instead of using the `wasm32-wasi` target:
+Since we don't need any system access for this, we can compile this to the lightweight `wasm32-unknown-unknown` target instead of using the `wasm32-wasi` target:
 
 ```bash
 cargo build --target wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Since we don't need any system access for this, we can compile this to the light
 cargo build --target wasm32-unknown-unknown
 ```
 
+> *Note*: You can also put a default target in `.cargo/config.yml`:
+> ```yaml
+> [build]
+>   target = "wasm32-unknown-unknown"
+> ```
+
 This will put your compiled wasm in `target/wasm32-unknown-unknown/debug`.
 We can now test it using the [Extism CLI](https://github.com/extism/cli)'s `run`
 command:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Extism Rust PDK
+
 [![crates.io](https://img.shields.io/crates/v/extism_pdk.svg)](https://crates.io/crates/extism-pdk)
 
 This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
@@ -63,8 +64,6 @@ Adding the [plugin_fn](https://docs.rs/extism-pdk/latest/extism_pdk/attr.plugin_
 
 A common thing you may want to do is pass some primitive rust data back and forth.
 The [plugin_fn](https://docs.rs/extism-pdk/latest/extism_pdk/attr.plugin_fn.html) macro can map these types for you:
-
-> TODO maybe link to docs.rs for convert here instead?
 
 > **Note**: The [plugin_fn](https://docs.rs/extism-pdk/latest/extism_pdk/attr.plugin_fn.html) macro uses the [convert crate](https://github.com/extism/extism/tree/main/convert) to automatically convert and pass types across the guest / host boundary.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
 
+* Crate: ![crates.io](https://img.shields.io/crates/v/extism_pdk.svg)
+* Docs: ![docs.rs](https://img.shields.io/docsrs/v/extism_pdk.svg)
+
 ## Install
 
 Make sure you generate a `lib` project:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Extism Rust PDK
 
-This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
-
-* Crate: ![crates.io](https://img.shields.io/crates/v/extism_pdk.svg)
-* Docs: ![docs.rs](https://img.shields.io/docsrs/v/extism_pdk.svg)
+This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust. ![crates.io](https://img.shields.io/crates/v/extism_pdk.svg) ![docs.rs](https://img.shields.io/docsrs/v/extism-pdk.svg)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ plug-in. These can be useful to statically configure the plug-in with some data 
 
 ```rust
 #[plugin_fn]
-pub fn greet(_: ()) -> FnResult<String> {
+pub fn greet() -> FnResult<String> {
     let user = config::get("user").expect("'user' key set in config");
     Ok(format!("Hello, {}!", user))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Extism Rust PDK
-<img align="right" src="https://img.shields.io/crates/v/extism_pdk.svg">
-<img align="right" src="https://img.shields.io/docsrs/v/extism-pdk.svg">
+![crates.io](https://img.shields.io/crates/v/extism_pdk.svg)
 
 This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,28 @@ pub fn add(Json(add): Json<Add>) -> FnResult<Json<Sum>> {
 
 ### Raw Export Interface
 
-`plugin_fn` is a nice macro abstraction but there may be times where you want more control. You can code directly to the raw interface of exports.
+`plugin_fn` is a nice macro abstraction but there may be times where you want more control. You can code directly to the raw ABI interface of export functions.
 
-> TODO i've actually forgotten what this looks like, expand it and write out a useful example
 ```rust
-pub const unsafe extern "C" fn greet() -> i32 {
+#[no_mangle]
+pub unsafe extern "C" fn greet() -> i32 {
+    let name_bytes = extism_load_input();
+    let name = from_utf8(&name_bytes);
+
+    match name {
+        Err(e) => {
+            let err = format!("{:?}", e);
+            let mem = Memory::from_bytes(&err);
+            extism_error_set(mem.offset);
+            1i32
+        }
+        Ok(n) => {
+            let result = format!("Hello, {}!", n);
+            let mem = Memory::from_bytes(result);
+            mem.set_output();
+            0i32
+        }
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -206,12 +206,10 @@ pub fn log_stuff(_: ()) -> FnResult<()> {
 }
 ```
 
-> TODO: why doesn't this log out info?
-
 From [Extism CLI](https://github.com/extism/cli):
 
 ```bash
-extism call my_plugin.wasm log_stuff
+extism call my_plugin.wasm log_stuff --log-level=info
 2023/09/30 11:52:17 Some info!
 2023/09/30 11:52:17 A warning!
 2023/09/30 11:52:17 An error!

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Because Wasm modules by default do not have access to the system, printing to st
 
 ```rust
 #[plugin_fn]
-pub fn log_stuff(_: ()) -> FnResult<()> {
+pub fn log_stuff() -> FnResult<()> {
     log!(LogLevel::Info, "Some info!");
     log!(LogLevel::Warn, "A warning!");
     log!(LogLevel::Error, "An error!");

--- a/README.md
+++ b/README.md
@@ -87,13 +87,6 @@ pub fn process_bytes(input: Vec<u8>) -> FnResult<Vec<u8>> {
     Ok(input)
 }
 
-// empty unit
-// be aware that plugin_fn expects params, so for a void func
-// use this empty unit
-#[plugin_fn]
-pub fn hello(_: ()) -> FnResult<String> {
-    Ok("Hello, World!".into())
-}
 ```
 
 ### Json

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ host has loaded and not freed the plug-in. You can use [var::get](https://docs.r
 
 ```rust
 #[plugin_fn]
-pub fn count(_: ()) -> FnResult<i64> {
+pub fn count() -> FnResult<i64> {
     let mut c = var::get("count")?.unwrap_or(0);
     c = c + 1;
     var::set("count", c)?;

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ extism call target/wasm32-unknown-unknown/debug/my_plugin.wasm greet --input "Be
 
 ### More About Exports
 
-Adding the `plugin_fn` macro to your function does a couple things. It exposes your function as an export and it handles some of the lower level ABI details that allow you to express the high level types of your params and returns. Here are a few examples of exports you can define.
+Adding the `plugin_fn` macro to your function does a couple things. It exposes your function as an export and it handles some of the lower level ABI details that allow you to declare your Wasm function as if it were a normal rust function. Here are a few examples of exports you can define.
 
 ### Primitive Types
 
 A common thing you may want to do is pass some primitive rust data back and forth.
 The `plugin_fn` macro can map these types for you:
 
-> TODO maybe link to docs.rs for convert here?
+> TODO maybe link to docs.rs for convert here instead?
 
 > **Note**: The `plugin_fn` macro uses the [convert crate](https://github.com/extism/extism/tree/main/convert) to automatically convert and pass types across the guest / host boundary.
 
@@ -73,7 +73,7 @@ pub fn add_pi(input: f32) -> FnResult<f64> {
     Ok(input as f64 + 3.14f64)
 }
 
-// i32 and i64
+// i32, i64, u32, u64
 #[plugin_fn]
 pub fn sum_42(input: i32) -> FnResult<i64> {
     Ok(input as i64 + 42i64)
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn greet() -> i32 {
 ## Configs
 
 Configs are key-value pairs that can be passed in by the host when creating a
-plug-in. These can be useful to statically configure the plug-in with some config that exists across every function call. Here is a trivial example:
+plug-in. These can be useful to statically configure the plug-in with some data that exists across every function call. Here is a trivial example:
 
 ```rust
 #[plugin_fn]
@@ -194,6 +194,11 @@ Because Wasm modules by default do not have access to the system, printing to st
 ```rust
 #[plugin_fn]
 pub fn log_stuff(_: ()) -> FnResult<()> {
+    info!("Some info!");
+    warn!("A warning!");
+    error!("An error!");
+
+    // optionally you can use the log! macro
     log!(LogLevel::Info, "Some info!");
     log!(LogLevel::Warn, "A warning!");
     log!(LogLevel::Error, "An error!");

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Extism Rust PDK
+<img align="right" src="https://img.shields.io/crates/v/extism_pdk.svg">
+<img align="right" src="https://img.shields.io/docsrs/v/extism-pdk.svg">
 
-This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust. ![crates.io](https://img.shields.io/crates/v/extism_pdk.svg) ![docs.rs](https://img.shields.io/docsrs/v/extism-pdk.svg)
+This library can be used to write [Extism Plug-ins](https://extism.org/docs/concepts/plug-in) in Rust.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cargo build --target wasm32-unknown-unknown
 > *Note*: You can also put a default target in `.cargo/config.toml`:
 > ```toml
 > [build]
->   target = "wasm32-unknown-unknown"
+> target = "wasm32-unknown-unknown"
 > ```
 
 This will put your compiled wasm in `target/wasm32-unknown-unknown/debug`.

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -22,9 +22,13 @@ extern "C" {
     pub fn extism_log_error(offs: u64);
 }
 
-/// # Safety
+/// Loads a byte array from Extism's memory. Only use this if you
+/// have already considered the plugin_fn macro as well as the [extism_load_input] function.
 ///
-/// This function is used to access WASM memory
+/// # Arguments
+///
+/// * `offs` - The Extism offset pointer location to the memory
+/// * `data` - The pointer to byte slice result
 pub unsafe fn extism_load(offs: u64, data: &mut [u8]) {
     let ptr = data.as_mut_ptr();
 
@@ -45,9 +49,9 @@ pub unsafe fn extism_load(offs: u64, data: &mut [u8]) {
     }
 }
 
-/// # Safety
-///
-/// This function is used to access WASM memory
+/// Loads the input from the host as a raw byte vec.
+/// Consider using the plugin_fn macro to automatically
+/// handle inputs as function parameters.
 pub unsafe fn extism_load_input() -> Vec<u8> {
     let input_length = extism_input_length();
     let mut data = vec![0; input_length as usize];
@@ -71,9 +75,13 @@ pub unsafe fn extism_load_input() -> Vec<u8> {
     data
 }
 
-/// # Safety
+/// Stores a byte array into Extism's memory.
+/// Only use this after considering []
 ///
-/// This function is used to access WASM memory
+/// # Arguments
+///
+/// * `offs` - The Extism offset pointer location to store the memory
+/// * `data` - The byte array to store at that offset
 pub unsafe fn extism_store(offs: u64, data: &[u8]) {
     let ptr = data.as_ptr();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,20 @@ pub fn get_memory(key: impl AsRef<str>) -> Result<Option<Memory>, Error> {
     })))
 }
 
+/// Gets a config item passed in from the host. This item is read-only
+/// and static throughout the lifetime of the plug-in.
+///
+/// # Arguments
+///
+/// * `key` - A unique string key to identify the variable
+///
+/// # Examples
+///
+/// ```
+/// // let's assume we have a config object: { my_config: 42u32 }
+/// // which is a u32. We can default to 0 first time we fetch it if it's not present
+/// let my_config = config::get("my_config")?.unwrap_or(0u32);
+/// ```
 pub fn get(key: impl AsRef<str>) -> Result<Option<String>, Error> {
     Ok(get_memory(key)?.map(|x| x.to_string().expect("Config value is not a valid string")))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,13 @@ pub use std::arch::wasm32::v128;
 mod macros;
 
 pub mod bindings;
-pub mod config;
 pub mod memory;
 mod to_memory;
+
+/// Functions to read plug-in config
+pub mod config;
+
+/// Functions to manipulate plug-in variables
 pub mod var;
 
 #[cfg(feature = "http")]

--- a/src/var.rs
+++ b/src/var.rs
@@ -17,6 +17,20 @@ pub fn get_memory(key: impl AsRef<str>) -> Result<Option<Memory>, Error> {
     Ok(Some(Memory(memory)))
 }
 
+/// Gets a variable in the plug-in. This variable lives as long as the
+/// plug-in is loaded.
+///
+/// # Arguments
+///
+/// * `key` - A unique string key to identify the variable
+///
+/// # Examples
+///
+/// ```
+/// // let's assume we have a variable at `"my_var"`
+/// // which is a u32. We can default to 0 first time we fetch it:
+/// let my_var = var::get("my_var")?.unwrap_or(0u32);
+/// ```
 pub fn get<T: FromBytesOwned>(key: impl AsRef<str>) -> Result<Option<T>, Error> {
     match get_memory(key)?.map(|x| x.to_vec()) {
         Some(v) => Ok(Some(T::from_bytes(&v)?)),
@@ -24,6 +38,20 @@ pub fn get<T: FromBytesOwned>(key: impl AsRef<str>) -> Result<Option<T>, Error> 
     }
 }
 
+/// Set a variable in the plug-in. This variable lives as long as the
+/// plug-in is loaded. The value must have a [ToMemory] implementation.
+///
+/// # Arguments
+///
+/// * `key` - A unique string key to identify the variable
+/// * `val` - The value to set. Must have a [ToMemory] implementation
+///
+/// # Examples
+///
+/// ```
+/// var::set("my_u32_var", 42u32)?;
+/// var::set("my_str_var", "Hello, World!")?;
+/// ```
 pub fn set(key: impl AsRef<str>, val: impl ToMemory) -> Result<(), Error> {
     let val = val.to_memory()?;
     let key = Memory::from_bytes(key.as_ref().as_bytes())?;
@@ -31,6 +59,18 @@ pub fn set(key: impl AsRef<str>, val: impl ToMemory) -> Result<(), Error> {
     Ok(())
 }
 
+/// Removes a variable from the plug-in. This variable normally lives as long as the
+/// plug-in is loaded.
+///
+/// # Arguments
+///
+/// * `key` - A unique string key to identify the variable
+///
+/// # Examples
+///
+/// ```
+/// var::remove("my_var")?;
+/// ```
 pub fn remove(key: impl AsRef<str>) -> Result<(), Error> {
     let key = Memory::from_bytes(key.as_ref().as_bytes())?;
     unsafe { extism_var_set(key.offset(), 0) };


### PR DESCRIPTION
An attempt at a README for the PDKs. Should have a similar treatment to the SDKs. It should walk the user through the different high level features. It should link up to the concept docs and down to the ref docs to teach them how to find both.