### PR TITLE
fix: add correction to readme doc on http function

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Sometimes it is useful to let a plug-in make HTTP calls.
 
 ```rust
 #[plugin_fn]
-pub fn http_get(Json(req): Json<HttpRequest>) -> FnResult<HttpResponse> {
+pub fn http_get(Json(req): Json<HttpRequest>) -> FnResult<Vec<u8>> {
     let res = http::request::<()>(&req, None)?;
-    Ok(res)
+    Ok(res.body())
 }
 ```
 


### PR DESCRIPTION
For a follow-on PR to `extism_pdk`, we may want to consider an impl for `serde` traits (at least Serialize) on `HttpResponse`... as that struct only has a `memory` and `status` field, we'd have to do a custom impl to get the body etc.. but this could also incorporate some of the recent feature requests to include the response headers and other http bits. 