### PR TITLE
docs: add section on installing rustup and wasm32 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ crate_type = ["cdylib"]
 
 Our example below will use of the wasm32-unknown-unknown target. If this is not installed you will need to do so before this example will build. The easiest way to do this is use *rustup*. If you have *rustup* installed skip the next step.
 
-```toml
+```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 Once *rustup* is installed, add the wasm32-unknown-unknown target:
 
-```toml
+```bash
 rustup target add wasm32-unknown-unknown
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ Change your `Cargo.toml` to set the crate-type to `cdylib` (this instructs the c
 crate_type = ["cdylib"]
 ```
 
+### Rustup and wasm32-unknown-unknown installation
+
+Our example below will use of the wasm32-unknown-unknown target. If this is not installed you will need to do so before this example will build. The easiest way to do this is use *rustup*. If you have *rustup* installed skip the next step.
+
+```toml
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Once *rustup* is installed, add the wasm32-unknown-unknown target:
+
+```toml
+rustup target add wasm32-unknown-unknown
+```
+
+
 ## Getting Started
 
 The goal of writing an [Extism plug-in](https://extism.org/docs/concepts/plug-in) is to compile your Rust code to a Wasm module with exported functions that the host application can invoke. The first thing you should understand is creating an export. Let's write a simple program that exports a `greet` function which will take a name as a string and return a greeting string. For this, we use the `#[plugin_fn]` macro on our exported function:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ crate_type = ["cdylib"]
 
 ### Rustup and wasm32-unknown-unknown installation
 
-Our example below will use of the wasm32-unknown-unknown target. If this is not installed you will need to do so before this example will build. The easiest way to do this is use *rustup*. If you have *rustup* installed skip the next step.
+Our example below will use of the wasm32-unknown-unknown target. If this is not installed you will need to do so before this example will build. The easiest way to do this is use [`rustup`](https://rustup.rs/).
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Our example below will use of the wasm32-unknown-unknown target. If this is not 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Once *rustup* is installed, add the wasm32-unknown-unknown target:
+Once `rustup` is installed, add the `wasm32-unknown-unknown` target:
 
 ```bash
 rustup target add wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ crate_type = ["cdylib"]
 
 ### Rustup and wasm32-unknown-unknown installation
 
-Our example below will use of the wasm32-unknown-unknown target. If this is not installed you will need to do so before this example will build. The easiest way to do this is use [`rustup`](https://rustup.rs/).
+Our example below will use the `wasm32-unknown-unknown` target. If this is not installed you will need to do so before this example will build. The easiest way to do this is use [`rustup`](https://rustup.rs/).
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh


### PR DESCRIPTION
When working through the example as a first time rust dev.. I did not have rustup or the wasm32-unknown-unknown target installed. So I had problems building the example. This addition is to help those that may be in a similar boat ensuring they have the necessary target so the build will work.
