### PR TITLE
fix: Use handle.length instead of offset.

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -16,7 +16,7 @@ pub mod internal {
     }
 
     pub fn memory_bytes(handle: MemoryHandle) -> Vec<u8> {
-        let mut data = vec![0; handle.offset as usize];
+        let mut data = vec![0; handle.length as usize];
         unsafe { extism::load(handle.offset, &mut data) };
         data
     }


### PR DESCRIPTION
This was resulting in incomplete memory ranges when I was attempting to serde json some stuff.

>  EOF while parsing a string at line 2 column 163