### PR TITLE
fix: free parameters to host functions when using the `host_fn` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-pdk"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"
@@ -12,9 +12,9 @@ description = "Extism Plug-in Development Kit (PDK) for Rust"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-extism-pdk-derive = { path = "./derive", version = "1.3.0" }
-extism-manifest = { version = "1.2.0", optional = true }
-extism-convert = { version = "1.2.0", features = ["extism-pdk-path"] }
+extism-pdk-derive = { path = "./derive", version = "1.4.0" }
+extism-manifest = { version = "1.10.0", optional = true }
+extism-convert = { version = "1.10.0", features = ["extism-pdk-path"] }
 base64 = "0.22.1"
 
 [features]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-pdk-derive"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["The Extism Authors", "oss@extism.org"]
 license = "BSD-3-Clause"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -296,7 +296,9 @@ pub fn host_fn(
                         match &*t.pat {
                             syn::Pat::Ident(i) => {
                                 into_inputs
-                                    .push(quote!(extism_pdk::ToMemory::to_memory(&&#i)?.offset()));
+                                    .push(quote!(
+                                        extism_pdk::ManagedMemory::from(extism_pdk::ToMemory::to_memory(&&#i)?).offset()
+                                    ));
                             }
                             _ => panic!("invalid host function argument"),
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use anyhow::Error;
 pub use extism_convert::*;
 pub use extism_convert::{FromBytes, FromBytesOwned, ToBytes};
 pub use extism_pdk_derive::{host_fn, plugin_fn, shared_fn};
-pub use memory::{Memory, MemoryPointer};
+pub use memory::{ManagedMemory, Memory, MemoryPointer};
 pub use to_memory::ToMemory;
 
 #[cfg(feature = "http")]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,6 +2,8 @@ use crate::*;
 
 pub struct Memory(pub MemoryHandle);
 
+pub struct ManagedMemory(pub Memory);
+
 pub mod internal {
     use super::*;
 
@@ -193,5 +195,43 @@ impl<T: FromBytesOwned> MemoryPointer<T> {
             Some(mem) => T::from_bytes_owned(&mem.to_vec()),
             None => anyhow::bail!("Invalid pointer offset {}", self.0),
         }
+    }
+}
+
+impl Drop for ManagedMemory {
+    fn drop(&mut self) {
+        internal::memory_free((self.0).0)
+    }
+}
+
+impl ManagedMemory {
+    pub fn new(mem: Memory) -> Self {
+        ManagedMemory(mem)
+    }
+
+    pub fn offset(&self) -> u64 {
+        self.0.offset()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl From<Memory> for ManagedMemory {
+    fn from(value: Memory) -> Self {
+        ManagedMemory(value)
+    }
+}
+
+impl AsRef<Memory> for ManagedMemory {
+    fn as_ref(&self) -> &Memory {
+        &self.0
+    }
+}
+
+impl AsMut<Memory> for ManagedMemory {
+    fn as_mut(&mut self) -> &mut Memory {
+        &mut self.0
     }
 }


### PR DESCRIPTION
- Avoids exhausting memory when making lots of host function calls, `host_fn` arguments are currently not freed and are not accessible to the user to free
- Adds the `ManagedMemory` type that can be used to free a memory block when dropped